### PR TITLE
Upgrade to .NET 6 and function v4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -293,6 +293,7 @@ dotnet_diagnostic.CA1410.severity = warning
 dotnet_diagnostic.CA1415.severity = warning
 dotnet_diagnostic.CA1812.severity = suggestion
 dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.CA1848.severity = suggestion
 dotnet_diagnostic.CA1900.severity = warning
 dotnet_diagnostic.CA1901.severity = warning
 dotnet_diagnostic.CA2002.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -522,3 +522,12 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = none
 dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
+
+###############################
+# Code Style rules (IDE)      #
+###############################
+
+# See rules here: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -338,6 +338,7 @@ dotnet_diagnostic.CA2238.severity = warning
 dotnet_diagnostic.CA2240.severity = warning
 dotnet_diagnostic.CA2241.severity = warning
 dotnet_diagnostic.CA2242.severity = warning
+dotnet_diagnostic.CA2254.severity = suggestion
 dotnet_diagnostic.CS1591.severity = none
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1000.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -270,7 +270,10 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
-# Analyzers/StyleCop rules
+###############################
+# .NET Analyzers              #
+###############################
+
 dotnet_diagnostic.CA1303.severity = suggestion
 dotnet_diagnostic.CA1715.severity = error
 dotnet_diagnostic.CA1001.severity = warning
@@ -340,6 +343,15 @@ dotnet_diagnostic.CA2241.severity = warning
 dotnet_diagnostic.CA2242.severity = warning
 dotnet_diagnostic.CA2254.severity = suggestion
 dotnet_diagnostic.CS1591.severity = none
+
+dotnet_code_quality.CA1062.null_check_validation_methods = ThrowIfNull|ThrowIfNullOrWhiteSpace
+
+###############################
+# StyleCop Analyzers          #
+###############################
+
+# See rules here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
+
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1000.severity = error
 dotnet_diagnostic.SA1001.severity = error
@@ -510,4 +522,3 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = none
 dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
-dotnet_code_quality.CA1062.null_check_validation_methods = ThrowIfNull|ThrowIfNullOrWhiteSpace

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,12 +33,12 @@ jobs:
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
-  
+
   update_coverage_report:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       USE_COSMOS_DB_EMULATOR: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.3.0
 
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       USE_COSMOS_DB_EMULATOR: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -43,18 +43,18 @@ jobs:
 
   entry_point_ci:
     needs: [ci_base, dotnet_solution_ci, terraform_validate]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.EntryPoint/Energinet.DataHub.MessageArchive.EntryPoint.csproj'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: entrypoint
 
   webapi_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.EntryPoint.WebApi/Energinet.DataHub.MessageArchive.EntryPoint.WebApi.csproj'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: webapi
 
   create_prerelease:
@@ -66,4 +66,4 @@ jobs:
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-message-archive
     secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.sln'
       DOTNET_VERSION: '6.0.201'
       USE_COSMOS_DB_EMULATOR: true
+      USE_AZURE_FUNCTIONS_TOOLS: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/search-logs-client-publish.yml
+++ b/.github/workflows/search-logs-client-publish.yml
@@ -45,7 +45,7 @@ env:
   # Conditions
   PUSH_PACKAGES: ${{ github.event_name != 'pull_request' }}
   # Tool versions
-  DOTNET_VERSION: '5.0.404'
+  DOTNET_VERSION: '6.0.201'
   AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
@@ -64,11 +64,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-
-      - name: Setup .NET 3.1 environment
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -22,7 +22,7 @@ module "app_webapi" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
-  dotnet_framework_version                  = "v5.0"
+  dotnet_framework_version                  = "v6.0"
 
   app_settings = {
     APPINSIGHTS_INSTRUMENTATIONKEY                    = "${data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value}"

--- a/build/infrastructure/main/func-entrypoint.tf
+++ b/build/infrastructure/main/func-entrypoint.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_entrypoint_messagearchive" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.4.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "entrypoint"
   project_name                              = var.domain_name_short
@@ -22,6 +22,7 @@ module "func_entrypoint_messagearchive" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values
@@ -35,6 +36,6 @@ module "func_entrypoint_messagearchive" {
     STORAGE_MESSAGE_ARCHIVE_PROCESSED_CONTAINER_NAME  = data.azurerm_key_vault_secret.st_market_operator_logs_archive_container_name.value
     COSMOS_MESSAGE_ARCHIVE_CONNECTION_STRING          = local.cosmos_db_connection_string
   }
-  
+
   tags                                      = azurerm_resource_group.this.tags
 }

--- a/build/infrastructure/main/kv-shared-resources.tf
+++ b/build/infrastructure/main/kv-shared-resources.tf
@@ -41,6 +41,11 @@ data "azurerm_key_vault_secret" "plan_shared_id" {
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
 
+data "azurerm_key_vault_secret" "log_shared_id" {
+  name         = "log-shared-id"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}
+
 data "azurerm_key_vault_secret" "frontend_open_id_url" {
   name         = "frontend-open-id-url"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id

--- a/build/infrastructure/main/variables.tf
+++ b/build/infrastructure/main/variables.tf
@@ -45,3 +45,8 @@ variable shared_resources_resource_group_name {
   type          = string
   description   = "Name of the Resource Group, that contains the shared resources."
 }
+
+data "azurerm_key_vault_secret" "log_shared_id" {
+  name         = "log-shared-id"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}

--- a/build/infrastructure/main/variables.tf
+++ b/build/infrastructure/main/variables.tf
@@ -45,8 +45,3 @@ variable shared_resources_resource_group_name {
   type          = string
   description   = "Name of the Resource Group, that contains the shared resources."
 }
-
-data "azurerm_key_vault_secret" "log_shared_id" {
-  name         = "log-shared-id"
-  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
-}

--- a/docs/message-archive-client/release-notes/release-notes.md
+++ b/docs/message-archive-client/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # MessageArchive.Client Release notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade
+
 ## Version 1.0.0
 
 - Preparing packages for initial release.

--- a/source/Energinet.DataHub.MessageArchive.Client.Abstractions/Energinet.DataHub.MessageArchive.Client.Abstractions.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client.Abstractions/Energinet.DataHub.MessageArchive.Client.Abstractions.csproj
@@ -25,7 +25,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageArchive.Client.Abstractions</PackageId>
-    <PackageVersion>1.5.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>MessageArchives client abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageArchive.Client.Abstractions/Energinet.DataHub.MessageArchive.Client.Abstractions.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client.Abstractions/Energinet.DataHub.MessageArchive.Client.Abstractions.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/source/Energinet.DataHub.MessageArchive.Client.Tests/Energinet.DataHub.MessageArchive.Client.Tests.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client.Tests/Energinet.DataHub.MessageArchive.Client.Tests.csproj
@@ -26,6 +26,10 @@ limitations under the License.
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
       <PackageReference Include="Moq" Version="4.16.1" />
       <PackageReference Include="xunit.categories" Version="2.0.5" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Energinet.DataHub.MessageArchive.Client.Tests/Energinet.DataHub.MessageArchive.Client.Tests.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client.Tests/Energinet.DataHub.MessageArchive.Client.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/source/Energinet.DataHub.MessageArchive.Client/Energinet.DataHub.MessageArchive.Client.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client/Energinet.DataHub.MessageArchive.Client.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/source/Energinet.DataHub.MessageArchive.Client/Energinet.DataHub.MessageArchive.Client.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client/Energinet.DataHub.MessageArchive.Client.csproj
@@ -24,7 +24,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageArchive.Client</PackageId>
-    <PackageVersion>1.5.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>MessageArchive client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageArchive.Common/Energinet.DataHub.MessageArchive.Common.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Common/Energinet.DataHub.MessageArchive.Common.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MessageArchive.EntryPoint.WebApi/Energinet.DataHub.MessageArchive.EntryPoint.WebApi.csproj
+++ b/source/Energinet.DataHub.MessageArchive.EntryPoint.WebApi/Energinet.DataHub.MessageArchive.EntryPoint.WebApi.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-      <TargetFramework>net5.0</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <LangVersion>9.0</LangVersion>
       <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/source/Energinet.DataHub.MessageArchive.EntryPoint/Energinet.DataHub.MessageArchive.EntryPoint.csproj
+++ b/source/Energinet.DataHub.MessageArchive.EntryPoint/Energinet.DataHub.MessageArchive.EntryPoint.csproj
@@ -21,6 +21,7 @@ limitations under the License.
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />

--- a/source/Energinet.DataHub.MessageArchive.EntryPoint/Energinet.DataHub.MessageArchive.EntryPoint.csproj
+++ b/source/Energinet.DataHub.MessageArchive.EntryPoint/Energinet.DataHub.MessageArchive.EntryPoint.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -15,9 +15,9 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <Nullable>enable</Nullable>

--- a/source/Energinet.DataHub.MessageArchive.EntryPoint/Functions/RequestResponseLogTriggerFunction.cs
+++ b/source/Energinet.DataHub.MessageArchive.EntryPoint/Functions/RequestResponseLogTriggerFunction.cs
@@ -45,7 +45,7 @@ namespace Energinet.DataHub.MessageArchive.EntryPoint.Functions
             await _blobProcessingHandler.HandleAsync().ConfigureAwait(false);
 
             stopWatch.Stop();
-            _logger.LogInformation("RequestResponseLogTriggerFunction executed, time ms: {time}", stopWatch.ElapsedMilliseconds);
+            _logger.LogInformation("RequestResponseLogTriggerFunction executed, time ms: {Time}", stopWatch.ElapsedMilliseconds);
         }
     }
 }

--- a/source/Energinet.DataHub.MessageArchive.EntryPoint/Program.cs
+++ b/source/Energinet.DataHub.MessageArchive.EntryPoint/Program.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Energinet.DataHub.MessageArchive.Common.SimpleInjector;
 using Microsoft.Extensions.Hosting;
@@ -21,6 +22,7 @@ namespace Energinet.DataHub.MessageArchive.EntryPoint
 {
     public static class Program
     {
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public static async Task Main()
         {
             await using var startup = new Startup();

--- a/source/Energinet.DataHub.MessageArchive.IntegrationTests/.editorconfig
+++ b/source/Energinet.DataHub.MessageArchive.IntegrationTests/.editorconfig
@@ -1,0 +1,24 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MessageArchive.IntegrationTests/Energinet.DataHub.MessageArchive.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MessageArchive.IntegrationTests/Energinet.DataHub.MessageArchive.IntegrationTests.csproj
@@ -29,11 +29,13 @@ limitations under the License.
         <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.24.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Moq" Version="4.16.1" />
-        <PackageReference Include="NUnit" Version="3.13.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
         <PackageReference Include="coverlet.collector" Version="3.0.2" />
         <PackageReference Include="xunit" Version="2.4.2-pre.12" />
         <PackageReference Include="xunit.categories" Version="2.0.5" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Energinet.DataHub.MessageArchive.IntegrationTests/Energinet.DataHub.MessageArchive.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MessageArchive.IntegrationTests/Energinet.DataHub.MessageArchive.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MessageArchive.PersistanceModels/Energinet.DataHub.MessageArchive.PersistanceModels.csproj
+++ b/source/Energinet.DataHub.MessageArchive.PersistanceModels/Energinet.DataHub.MessageArchive.PersistanceModels.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MessageArchive.Persistence/Energinet.DataHub.MessageArchive.Persistence.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Persistence/Energinet.DataHub.MessageArchive.Persistence.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MessageArchive.Processing/Energinet.DataHub.MessageArchive.Processing.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Processing/Energinet.DataHub.MessageArchive.Processing.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MessageArchive.Processing/Handlers/BlobProcessingHandler.cs
+++ b/source/Energinet.DataHub.MessageArchive.Processing/Handlers/BlobProcessingHandler.cs
@@ -64,7 +64,7 @@ namespace Energinet.DataHub.MessageArchive.Processing.Handlers
                 catch (Exception e)
 #pragma warning restore CA1031
                 {
-                    _processingLogger.LogError(e, "Error in processing item: {name}", blobItemData.Name);
+                    _processingLogger.LogError(e, "Error in processing item: {Name}", blobItemData.Name);
                     await ParseAndSaveAsync(new LogParserBlobProperties(), blobItemData).ConfigureAwait(false);
                 }
             }

--- a/source/Energinet.DataHub.MessageArchive.Reader/Energinet.DataHub.MessageArchive.Reader.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Reader/Energinet.DataHub.MessageArchive.Reader.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MessageArchive.Tests/Energinet.DataHub.MessageArchive.Tests.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Tests/Energinet.DataHub.MessageArchive.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>net5.0</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <Nullable>enable</Nullable>
       <IsPackable>false</IsPackable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MessageArchive.Tests/Energinet.DataHub.MessageArchive.Tests.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Tests/Energinet.DataHub.MessageArchive.Tests.csproj
@@ -30,8 +30,6 @@ limitations under the License.
         <PackageReference Include="xunit" Version="2.4.2-pre.12" />
         <PackageReference Include="FluentAssertions" Version="6.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="NUnit" Version="3.13.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
         <PackageReference Include="coverlet.collector" Version="3.0.2" />
         <PackageReference Include="xunit.categories" Version="2.0.5" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/source/Energinet.DataHub.MessageArchive.Utilities/Energinet.DataHub.MessageArchive.Utilities.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Utilities/Energinet.DataHub.MessageArchive.Utilities.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
## Description

Upgrade Message Archive to .NET 6 and function v4.

Important:
* Focus is on upgrading to .NET 6 and functions v4. Only NuGet packages directly impacted by this (meaning Analyzers) has been updated.
* NuGet packages build within the domain has also been updated to .NET 6 and all version numbers bumped to the next major version to signal the "breaking change". It means that any domain that want to use these packages in the future, must update their domain to .NET 6 (which is what we want anyway).

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/258
