### PR TITLE
Remove DOTNET_VERSION

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,13 +20,13 @@ on:
 
 jobs:
   publish_release:
-    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@7.7.0
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   dispatch_deployment_request:
     needs: publish_release
-    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@7.7.0
     with:
       CALLER_REPOSITORY_NAME: geh-message-archive
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-message-archive
@@ -35,10 +35,9 @@ jobs:
       ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
 
   update_coverage_report:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_COSMOS_DB_EMULATOR: true
       USE_AZURE_FUNCTIONS_TOOLS: true
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,12 @@ on:
 
 jobs:
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.7.0
 
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_COSMOS_DB_EMULATOR: true
       USE_AZURE_FUNCTIONS_TOOLS: true
       PREPARE_OUTPUTS: true
@@ -38,7 +37,7 @@ jobs:
       AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
 
   terraform_validate:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.7.0
     with:
       TERRAFORM_WORKING_DIR_PATH: './build/infrastructure/main'
       TERRAFORM_VERSION: '1.2.2'
@@ -49,7 +48,7 @@ jobs:
       dotnet_solution_ci,
       terraform_validate
     ]
-    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@7.7.0
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-message-archive
     secrets:


### PR DESCRIPTION
Speed up CI execution time by using default .NET Core SDK version pre-installed on hosted Github Runner

Reference: https://github.com/Energinet-DataHub/the-outlaws/issues/360