### PR TITLE
Use environment for OIDC login

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,7 @@ jobs:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MessageArchive.sln'
       USE_COSMOS_DB_EMULATOR: true
       USE_AZURE_FUNCTIONS_TOOLS: true
+      ENVIRONMENT: AzureAuth
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       USE_AZURE_FUNCTIONS_TOOLS: true
       PREPARE_OUTPUTS: true
       CODE_COVERAGE_FLAGS: business
+      ENVIRONMENT: AzureAuth
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/publish-messagearchive-client.yml
+++ b/.github/workflows/publish-messagearchive-client.yml
@@ -56,6 +56,8 @@ jobs:
     runs-on: windows-2022
     name: Publish bundle to NuGet.org
 
+    environment: AzureAuth
+
     steps:
       - name: Checkout repository
         uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@v8

--- a/docs/message-archive-client/release-notes/release-notes.md
+++ b/docs/message-archive-client/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # MessageArchive.Client Release notes
 
+## Version 2.0.6
+
+- Pipeline updated.
+
 ## Version 2.0.5
 
 - Cleanup and refactor.

--- a/source/Energinet.DataHub.MessageArchive.Client.Abstractions/Energinet.DataHub.MessageArchive.Client.Abstractions.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client.Abstractions/Energinet.DataHub.MessageArchive.Client.Abstractions.csproj
@@ -25,7 +25,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageArchive.Client.Abstractions</PackageId>
-    <PackageVersion>2.0.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.6$(VersionSuffix)</PackageVersion>
     <Title>MessageArchives client abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageArchive.Client/Energinet.DataHub.MessageArchive.Client.csproj
+++ b/source/Energinet.DataHub.MessageArchive.Client/Energinet.DataHub.MessageArchive.Client.csproj
@@ -24,7 +24,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageArchive.Client</PackageId>
-    <PackageVersion>2.0.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.6$(VersionSuffix)</PackageVersion>
     <Title>MessageArchive client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
## Description

Change federated credentials to use "environment" as "subject" when authenticating to Azure in workflows.

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/607

