### PR TITLE
Notify if deployment dispatch failed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,22 +59,8 @@ jobs:
 
   dispatch_deploment_event:
     runs-on: ubuntu-latest
-    needs: [
-      # Necessary to be able to use its outputs in the dispatch event
-      changes,
-      # .NET
-      dotnet_promote_prerelease,
-    ]
-    if: |
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      !(
-        needs.dotnet_promote_prerelease.result == 'skipped'
-      )
+    needs: dotnet_promote_prerelease
     steps:
-      - run: echo "${{ toJSON(needs) }}"
-
       - name: Find associated pull request
         uses: Energinet-DataHub/.github/.github/actions/find-related-pr-number@v9
         id: find_pull_request
@@ -86,3 +72,21 @@ jobs:
           repository: '${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}'
           event-type: 'message-archive-deployment-request-domain'
           client-payload: '{"domain_pr": "${{ steps.find_pull_request.outputs.pull_request_number }}"}'
+
+  #
+  # Send notification to teams channel if deployment dispatch failed
+  #
+
+  dispatch_failed:
+    needs: [
+      infrastructure_promote_prerelease,
+      dispatch_deploment_event,
+    ]
+    if: |
+      always() &&
+      contains(needs.*.result, 'failure')
+    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v9
+    with:
+      TEAM_NAME: 'Titans'
+      SUBJECT: 'Deployment dispatch failed: Message Archive'
+    secrets: inherit


### PR DESCRIPTION
Description
Notify teams in MS team channel if CD fails within domain repository.

References
https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/685
